### PR TITLE
Fix measurements method to always return `n` objects, where `n = numobs(y)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StatisticalMeasuresBase"
 uuid = "c062fc1d-0d66-479b-b6ac-8b44719de4cc"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/api.jl
+++ b/src/api.jl
@@ -11,8 +11,9 @@ on data.
 
 # New implementations
 
-Overloading this function is optional. A fallback returns the aggregated measure, repeated
-`n` times, where `n = MLUtils.numobs(y)`.  It is not typically necessary to overload
+Overloading this function for new measure types is optional. A fallback returns the
+aggregated measure, repeated `n` times, where `n = MLUtils.numobs(y)` (which falls back to
+`length(y)` if `numobs` is not implemented).  It is not typically necessary to overload
 `measurements` for wrapped measures.  All [`multimeasure`](@ref)s provide the obvious
 fallback and other wrappers simply forward the `measurements` method of the atomic
 measure. If overloading, use the following signatures:
@@ -24,7 +25,6 @@ measure. If overloading, use the following signatures:
 
 """
 function measurements(measure, yhat, y, args...)
-    consumes_multiple_observations(measure) || return measure(yhat, y, args...)
     m = measure(yhat, y, args...)
     fill(m, MLUtils.numobs(y))
 end

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -91,8 +91,9 @@ with the same number of observations as `y`.
 
 # New implementations
 
-Overloading the trait is optional and it is typically not overloaded. The general fallback
-returns `false` but it is `true` for any [`multimeasure`](@ref), and the value is
+Overload this trait for a new measure type that consumes multiple observations, unless it
+has been constructed using `multimeaure` or is an $API.jl wrap thereof. The general
+fallback returns `false` but it is `true` for any [`multimeasure`](@ref), and the value is
 propagated by other wrappers.
 
 """

--- a/test/api.jl
+++ b/test/api.jl
@@ -9,6 +9,12 @@ w = 10:10:10N
     measurements(measure, 2.3, 3.4) == LPLossOnScalars()(2.3, 3.4)
     measure = MeanAbsoluteError()
     measurements(measure, yhat, y) == fill(measure(yhat, y), N)
+
+    # if a measure does not overload `consumes_multiple_observations` but really does, then
+    # `meausurements` should nevertheless have the expected behavior:
+    badly_implemented_rms(yhat, y) = (yhat - y).^2 |> mean |> sqrt
+    μ = badly_implemented_rms([4, 5], [1, 1])
+    @test measurements(badly_implemented_rms, [4, 5], [1, 1]) ≈ [μ, μ]
 end
 
 true

--- a/test/measure.jl
+++ b/test/measure.jl
@@ -9,7 +9,7 @@ API.is_measure(::Measure{typeof(min)}) = true
 @testset "calling" begin
     measure = Measure(min)
     @test measure(2, -3) == 3
-    @test measurements(measure, 2, -3) == 3
+    @test measurements(measure, 2, -3) == [3,]
 end
 
 true


### PR DESCRIPTION
Even if `can_report_unaggregated` is `false`. 

Regarding this as "bug" fix. 